### PR TITLE
Switch to tag based releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -179,6 +179,8 @@ jobs:
             cp x86_64/libblst.so ./src/main/resources/x86_64/
             cp blst.dll ./src/main/resources/x86_64/
             ./gradlew --no-daemon --parallel build
+      - persist_to_workspace:
+          root: .
   publish:
     executor: linux_executor
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -164,7 +164,7 @@ jobs:
     steps:
       - checkout_code
       - prepare_windows
-  assemble-and-publish:
+  assemble:
     executor: linux_executor
     steps:
       - checkout_code
@@ -179,23 +179,62 @@ jobs:
             cp x86_64/libblst.so ./src/main/resources/x86_64/
             cp blst.dll ./src/main/resources/x86_64/
             ./gradlew --no-daemon --parallel build
+  publish:
+    executor: linux_executor
+    steps:
+      - checkout_code
+      - attach_workspace:
+          at: .
+      - run:
+          name: Publish
+          command: |
             ./gradlew --no-daemon --parallel publish
 
 workflows:
   version: 2
   default:
     jobs:
-      - x86-64-linux-build
-      - arm64-linux-build
-      - mac-os-build
-      - windows-build
-      - assemble-and-publish:
+      - x86-64-linux-build:
+          filters:
+            tags: &filters-release-tags
+              only: /^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+)?/
+          context:
+            - dockerhub-quorumengineering-ro
+      - arm64-linux-build:
+          filters:
+            tags:
+              <<: *filters-release-tags
+          context:
+            - dockerhub-quorumengineering-ro
+      - mac-os-build:
+          filters:
+            tags:
+              <<: *filters-release-tags
+          context:
+            - dockerhub-quorumengineering-ro
+      - windows-build:
+          filters:
+            tags:
+              <<: *filters-release-tags
+          context:
+            - dockerhub-quorumengineering-ro
+      - assemble:
           requires:
             - x86-64-linux-build
             - arm64-linux-build
             - mac-os-build
             - windows-build
           filters:
+            tags:
+              <<: *filters-release-tags
+          context:
+            - dockerhub-quorumengineering-ro
+      - publish:
+          requires:
+            - assemble
+          filters:
+            tags:
+              <<: *filters-release-tags
             branches:
               only:
                 - master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -181,6 +181,8 @@ jobs:
             ./gradlew --no-daemon --parallel build
       - persist_to_workspace:
           root: .
+          paths:
+            - ./
   publish:
     executor: linux_executor
     steps:

--- a/build.gradle
+++ b/build.gradle
@@ -1,13 +1,17 @@
 plugins {
     id 'maven-publish'
+    id 'org.ajoberstar.grgit' version '4.0.2'
 }
+
+rootProject.version = calculatePublishVersion()
+def specificVersion = calculateVersion()
+def isDevelopBuild = rootProject.version.contains('develop')
 
 apply plugin: 'java'
 apply plugin: 'maven'
 apply plugin: 'maven-publish'
 
 group = 'tech.pegasys'
-version = '0.3.2-RELEASE'
 
 sourceCompatibility = 11
 targetCompatibility = 11
@@ -97,5 +101,46 @@ publishing {
         }
       }
     }
+  }
+}
+
+// Calculate the version that this build would be published under (if it is published)
+// If this exact commit is tagged, use the tag
+// If this is on a release-* branch, use the most recent tag appended with +develop (e.g. 0.1.1-RC1+develop)
+// Otherwise, use develop
+def calculatePublishVersion() {
+  if (!grgit) {
+    return 'UNKNOWN'
+  }
+  def specificVersion = calculateVersion()
+  def isReleaseBranch = grgit.branch.current().name.startsWith('release-')
+  if (specificVersion.contains('+')) {
+    return isReleaseBranch ? "${specificVersion.substring(0, specificVersion.indexOf('+'))}+develop" : "develop"
+  }
+  return specificVersion
+}
+
+// Calculate the version that teku --version will report (among other places)
+// If this exact commit is tagged, use the tag
+// Otherwise use git describe --tags and replace the - after the tag with a +
+def calculateVersion() {
+  if (!grgit) {
+    return 'UNKNOWN'
+  }
+  String version = grgit.describe(tags: true)
+  if (version == null) {
+    return 'UNKNOWN'
+  }
+  def versionPattern = ~/^(?<lastVersion>.*)-(?<devVersion>[0-9]+-g[a-z0-9]+)$/
+  def matcher = version =~ versionPattern
+  if (matcher.find()) {
+    return "${matcher.group("lastVersion")}+${matcher.group("devVersion")}"
+  }
+  return version
+}
+
+task printVersion() {
+  doFirst {
+    print "Specific version: ${specificVersion}  Publish version: ${project.version}"
   }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'maven-publish'
-    id 'org.ajoberstar.grgit' version '4.0.2'
+    id 'org.ajoberstar.grgit' version '4.1.0'
 }
 
 rootProject.version = calculatePublishVersion()


### PR DESCRIPTION
Switch to using tag based releases.

Separate the assemble and publish steps so assemble is tested as part of PR builds rather than only running on mainnet.