### PR TITLE
Build libblst with GCC for consistency

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -185,7 +185,7 @@ jobs:
           command: |
             $Env:PATH = "$PWD\tdm\install\bin;$Env:PATH"
             cd blst\bindings\java
-            ..\..\build.bat -D__BLST_PORTABLE__
+            sh ..\..\build.sh -D__BLST_PORTABLE__
             sh .\run.me
       - persist_to_workspace:
           root: ./


### PR DESCRIPTION
Previously it was trying to build it with Visual C compiler but run.me will wind up rebuilding with gcc. We could have potentially wound up with the portable flag being lost.

Pretty sure Visual C compiler isn't on the PATH for these windows boxes anyway so suspect the original build.bat call just wasn't doing anything.