### PR TITLE
Revert "Build libblst with GCC for consistency. (#24)"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -185,7 +185,7 @@ jobs:
           command: |
             $Env:PATH = "$PWD\tdm\install\bin;$Env:PATH"
             cd blst\bindings\java
-            sh ..\..\build.sh -D__BLST_PORTABLE__
+            ..\..\build.bat -D__BLST_PORTABLE__
             sh .\run.me
       - persist_to_workspace:
           root: ./


### PR DESCRIPTION
Seeing reduced compatibility with this change. Specifically the CircleCI executor now fails to run all BLST tests. Ironically it's possible that we lost the portable build because of this change due to the complexities of passing stuff through Powershell and sh and onwards.