### PR TITLE
Backport support for specifying a custom resource path

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -321,6 +321,7 @@ jobs:
       - checkout
       - attach_workspace:
           at: ~/jblst
+      - apply_patches
       - run:
           name: Copy BLST Sources
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,6 +34,14 @@ commands:
           command: |
             git submodule init
             git submodule update
+  apply_patches:
+    description: "Prepare - Apply Patches"
+    steps:
+      - run:
+          name: "Apply patches"
+          command: |
+            cd blst
+            git apply ../blst.patch
 
   install_linux_swig4:
     description: "Install Swig4"
@@ -61,6 +69,7 @@ jobs:
     steps:
       - checkout_code
       - install_linux_swig4
+      - apply_patches
       - run:
           name: "Build Linux AMD Library (Portable)"
           command: |
@@ -103,6 +112,7 @@ jobs:
     steps:
       - checkout_code
       - install_linux_swig4
+      - apply_patches
       - run:
           name: "Install Cross Compiler"
           command: |
@@ -151,6 +161,7 @@ jobs:
       SKIP_GRADLE: true
     steps:
       - checkout_code
+      - apply_patches
       - run:
           name: Install dependencies
           command: |
@@ -232,6 +243,7 @@ jobs:
       SKIP_GRADLE: true
     steps:
       - checkout_code
+      - apply_patches
       - run:
           name: Install dependencies
           command: |
@@ -269,6 +281,7 @@ jobs:
       SKIP_GRADLE: true
     steps:
       - checkout_code
+      - apply_patches
       - run:
           name: Install dependencies
           command: |
@@ -305,7 +318,7 @@ jobs:
   assemble:
     executor: linux_executor
     steps:
-      - checkout_code
+      - checkout
       - attach_workspace:
           at: ~/jblst
       - run:

--- a/blst.patch
+++ b/blst.patch
@@ -1,0 +1,28 @@
+commit 5e8c286808afc43a2fa25b58df0dfd6de8f01190
+Author: Adrian Sutton <adrian.sutton@consensys.net>
+Date:   Thu Dec 2 21:35:28 2021 +1000
+
+    bindings/blst.swg: facilitate custom Java Native Interface library path.
+    
+    This makes the native library loading significantly more flexible. In
+    particular, applications can embed native components built for both
+    optimised and portable profiles and dynamically select which to load
+    at runtime.
+    
+    Fixes #91.
+
+diff --git a/bindings/blst.swg b/bindings/blst.swg
+index ab9a0a7..0f72d53 100644
+--- a/bindings/blst.swg
++++ b/bindings/blst.swg
+@@ -350,7 +350,9 @@ import java.nio.file.*;
+                                 + "/" + System.getProperty("os.arch")
+                                 + "/" + libName;
+     static {
+-        InputStream res = $imclassname.class.getResourceAsStream(resName);
++        Class<?> imClazz = $imclassname.class;
++        InputStream res = imClazz.getResourceAsStream(
++                        System.getProperty(imClazz.getPackageName() + ".jniResource", resName));
+         if (res == null) {
+             try {
+                 System.loadLibrary("$module");


### PR DESCRIPTION
Applies as a patch until the next release so we don't need to pull in other changes.