### PR TITLE
Update to 0.3.17

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -185,7 +185,7 @@ jobs:
             cd blst\bindings\java
             ..\..\build.bat -D__BLST_PORTABLE__
             if (-not $?) {
-              throw 'Build failed'
+              throw "Build failed Error: $($Error[0])"
             }
             sh .\run.me -D__BLST_PORTABLE__
             if (-not $?) {

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -181,28 +181,16 @@ jobs:
       - run:
           name: Generate windows shared lib
           command: |
-            try {
-                  # Update PATH environment variable
-                  $Env:PATH = "$PWD\tdm\install\bin;$Env:PATH"
-            
-                  # Change to the Java bindings directory
-                  cd blst\bindings\java
-            
-                  # Run the build script
-                  ..\..\build.bat -D__BLST_PORTABLE__
-                  if (-not $?) {
-                  throw "Build failed. Error: $($Error[0])"
-                }
-            
-                  # Run the test script
-                  sh .\run.me -D__BLST_PORTABLE__
-                  if (-not $?) {
-                  throw "Tests failed. Error: $($Error[0])"
-                }
-            } catch {
-              # Catch any errors and output them
-              Write-Error "An error occurred: $_"
-              exit 1
+            $ErrorActionPreference = 'SilentlyContinue'
+            $Env:PATH = "$PWD\tdm\install\bin;$Env:PATH"
+            cd blst\bindings\java
+            ..\..\build.bat -D__BLST_PORTABLE__ -Verbose
+            if (-not $?) {
+              throw 'Build failed Error: '
+            }
+            sh .\run.me -D__BLST_PORTABLE__
+            if (-not $?) {
+              throw 'Tests failed'
             }
 
       - persist_to_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -181,7 +181,6 @@ jobs:
       - run:
           name: Generate windows shared lib
           command: |
-            $ErrorActionPreference = 'SilentlyContinue'
             $Env:PATH = "$PWD\tdm\install\bin;$Env:PATH"
             cd blst\bindings\java
             ..\..\build.bat -D__BLST_PORTABLE__

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ executors:
       GRADLE_OPTS: -Xmx2048m -Dorg.gradle.daemon=false -Dorg.gradle.parallel=true -Dorg.gradle.workers.max=2
   mac_os_executor:
     macos:
-      xcode: "14.3.1"
+      xcode: "16.4.0"
     resource_class: macos.m1.medium.gen1
     working_directory: ~/jblst
     environment:
@@ -117,10 +117,7 @@ jobs:
       - run:
           name: Install dependencies
           command: |
-            echo "Installing openjdk 11 for test execution"
-            brew install openjdk@11
-            sudo ln -sfn /usr/local/opt/openjdk@11/libexec/openjdk.jdk /Library/Java/JavaVirtualMachines/openjdk-11.jdk
-
+            
             echo "Installing swig"
             brew install swig@4
             brew install gnu-sed

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ executors:
     working_directory: ~/jblst
     environment:
       GRADLE_OPTS: -Xmx2048m -Dorg.gradle.daemon=false -Dorg.gradle.parallel=true -Dorg.gradle.workers.max=2
-      HOMEBREW_NO_AUTO_UPDATE: false
+      HOMEBREW_NO_AUTO_UPDATE: true
 
 commands:
   checkout_code:
@@ -117,6 +117,7 @@ jobs:
       - run:
           name: Install dependencies
           command: |
+            brew install libpng
             echo "Installing openjdk 11 for test execution"
             brew install openjdk@11
             sudo ln -sfn /usr/local/opt/openjdk@11/libexec/openjdk.jdk /Library/Java/JavaVirtualMachines/openjdk-11.jdk

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,7 +119,7 @@ jobs:
           command: |
             
             echo "Installing swig"
-            brew install swig@4
+            brew install swig
             brew install gnu-sed
 
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -184,7 +184,7 @@ jobs:
             $ErrorActionPreference = 'SilentlyContinue'
             $Env:PATH = "$PWD\tdm\install\bin;$Env:PATH"
             cd blst\bindings\java
-            ..\..\build.bat -D__BLST_PORTABLE__ -Verbose
+            ..\..\build.bat -D__BLST_PORTABLE__
             if (-not $?) {
               throw 'Build failed Error: '
             }

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,7 +117,7 @@ jobs:
       - run:
           name: Install dependencies
           command: |
-            brew install libpng
+            brew update
             echo "Installing openjdk 11 for test execution"
             brew install openjdk@11
             sudo ln -sfn /usr/local/opt/openjdk@11/libexec/openjdk.jdk /Library/Java/JavaVirtualMachines/openjdk-11.jdk

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -183,7 +183,7 @@ jobs:
           command: |
             $Env:PATH = "$PWD\tdm\install\bin;$Env:PATH"
             cd blst\bindings\java
-            ..\..\build.bat -shared
+            ..\..\build.bat -D__BLST_PORTABLE__
             sh .\run.me -D__BLST_PORTABLE__
             if (-not $?) {
               throw 'Tests failed'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,5 @@
 ---
-version: 2.1
+version: 2.2
 
 orbs:
   win: circleci/windows@2.2.0
@@ -183,10 +183,7 @@ jobs:
           command: |
             $Env:PATH = "$PWD\tdm\install\bin;$Env:PATH"
             cd blst\bindings\java
-            ..\..\build.bat -D__BLST_PORTABLE__
-            if (-not $?) {
-              throw 'Build failed'
-            }
+            ..\..\build.bat -shared
             sh .\run.me -D__BLST_PORTABLE__
             if (-not $?) {
               throw 'Tests failed'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,5 @@
 ---
-version: 2.2
+version: 2.1
 
 orbs:
   win: circleci/windows@2.2.0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -186,7 +186,7 @@ jobs:
             cd blst\bindings\java
             ..\..\build.bat -D__BLST_PORTABLE__
             if (-not $?) {
-              throw 'Build failed Error: '
+              throw 'Build failed'
             }
             sh .\run.me -D__BLST_PORTABLE__
             if (-not $?) {

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -181,15 +181,28 @@ jobs:
       - run:
           name: Generate windows shared lib
           command: |
-            $Env:PATH = "$PWD\tdm\install\bin;$Env:PATH"
-            cd blst\bindings\java
-            ..\..\build.bat -D__BLST_PORTABLE__
-            if (-not $?) {
-              throw "Build failed Error: $($Error[0])"
-            }
-            sh .\run.me -D__BLST_PORTABLE__
-            if (-not $?) {
-              throw 'Tests failed'
+            try {
+                  # Update PATH environment variable
+                  $Env:PATH = "$PWD\tdm\install\bin;$Env:PATH"
+            
+                  # Change to the Java bindings directory
+                  cd blst\bindings\java
+            
+                  # Run the build script
+                  ..\..\build.bat -D__BLST_PORTABLE__
+                  if (-not $?) {
+                  throw "Build failed. Error: $($Error[0])"
+                }
+            
+                  # Run the test script
+                  sh .\run.me -D__BLST_PORTABLE__
+                  if (-not $?) {
+                  throw "Tests failed. Error: $($Error[0])"
+                }
+            } catch {
+              # Catch any errors and output them
+              Write-Error "An error occurred: $_"
+              exit 1
             }
 
       - persist_to_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ executors:
     working_directory: ~/jblst
     environment:
       GRADLE_OPTS: -Xmx2048m -Dorg.gradle.daemon=false -Dorg.gradle.parallel=true -Dorg.gradle.workers.max=2
-      HOMEBREW_NO_AUTO_UPDATE: true
+      HOMEBREW_NO_AUTO_UPDATE: false
 
 commands:
   checkout_code:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ executors:
       GRADLE_OPTS: -Xmx2048m -Dorg.gradle.daemon=false -Dorg.gradle.parallel=true -Dorg.gradle.workers.max=2
   mac_os_executor:
     macos:
-      xcode: "14.2.0"
+      xcode: "14.3.1"
     resource_class: macos.m1.medium.gen1
     working_directory: ~/jblst
     environment:
@@ -117,7 +117,6 @@ jobs:
       - run:
           name: Install dependencies
           command: |
-            brew update
             echo "Installing openjdk 11 for test execution"
             brew install openjdk@11
             sudo ln -sfn /usr/local/opt/openjdk@11/libexec/openjdk.jdk /Library/Java/JavaVirtualMachines/openjdk-11.jdk

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ commands:
           name: "Install Swig4"
           command: |
             sudo apt-get update
-            sudo apt-get install -y automake autoconf libpcre2-dev pcre2-config bison flex
+            sudo apt-get install -y automake autoconf libpcre2-dev bison flex
             echo "Installing swig"
             curl -L -O https://github.com/swig/swig/archive/v4.4.1.tar.gz
             tar -xzvf v4.4.1.tar.gz

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,9 +44,9 @@ commands:
             sudo apt-get update
             sudo apt-get install -y automake autoconf libpcre3 libpcre3-dev bison flex
             echo "Installing swig"
-            curl -L -O https://github.com/swig/swig/archive/v4.0.2.tar.gz
-            tar -xzvf v4.0.2.tar.gz
-            cd swig-4.0.2/
+            curl -L -O https://github.com/swig/swig/archive/v4.4.1.tar.gz
+            tar -xzvf v4.4.1.tar.gz
+            cd swig-4.4.1/
             sh autogen.sh
             ./configure
             make

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ commands:
           name: "Install Swig4"
           command: |
             sudo apt-get update
-            sudo apt-get install -y automake autoconf libpcre3 libpcre3-dev bison flex
+            sudo apt-get install -y automake autoconf libpcre2-dev pcre2-config bison flex
             echo "Installing swig"
             curl -L -O https://github.com/swig/swig/archive/v4.4.1.tar.gz
             tar -xzvf v4.4.1.tar.gz

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'maven-publish'
-    id 'org.ajoberstar.grgit' version '4.1.0'
+    id 'org.ajoberstar.grgit' version '4.1.1'
 }
 
 rootProject.version = calculatePublishVersion()


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CI-only dependency version bumps for Linux Swig builds; no application runtime or auth/data-path changes.
> 
> **Overview**
> Updates the **Linux CircleCI** `install_linux_swig4` step so native Java bindings build against a newer toolchain.
> 
> **SWIG** is built from source **4.0.2 → 4.4.1** (download URL, tarball name, and build directory updated accordingly). **APT dependencies** switch from **`libpcre3` / `libpcre3-dev`** to **`libpcre2-dev`**, matching SWIG 4.4.x’s PCRE2 requirement.
> 
> Affects jobs that call `install_linux_swig4` (`x86-64-linux-build`, `arm64-linux-build`); macOS/Windows Swig install paths are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eeb1c76f49a01f4925cdfa7cac8e03d718b095ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->